### PR TITLE
qcollapsible suggestions

### DIFF
--- a/examples/collapsible.py
+++ b/examples/collapsible.py
@@ -1,39 +1,12 @@
 """Example for QCollapsible"""
-import sys
-
 from superqt import QCollapsible
-from superqt.qtcompat.QtCore import Qt
-from superqt.qtcompat.QtWidgets import QApplication, QPushButton, QVBoxLayout, QWidget
+from superqt.qtcompat.QtWidgets import QApplication, QPushButton
 
 app = QApplication([])
 
-main_widget = QWidget()
-main_widget.setMinimumWidth(500)
-main_widget.setMinimumHeight(700)
-
-layout = QVBoxLayout()
-layout.setAlignment(Qt.AlignTop)
-
-# Create child component
-inner_layout = QVBoxLayout()
-inner_widget = QWidget()
+collapsible = QCollapsible("Advanced analysis")
 for i in range(10):
-    conetent_button = QPushButton(text="Content button " + str(i + 1))
-    inner_layout.addWidget(conetent_button)
-inner_widget.setLayout(inner_layout)
+    collapsible.addWidget(QPushButton(f"Content button {i + 1}"))
 
-# Create collapsible
-collapsible = QCollapsible(
-    text="Advanced analysis",
-    content=inner_widget,
-    duration=500,
-    initial_is_checked=True,
-)
-
-layout.addWidget(collapsible)
-layout.addWidget(inner_widget)
-
-# Show
-main_widget.setLayout(layout)
-main_widget.show()
-sys.exit(app.exec_())
+collapsible.show()
+app.exec_()

--- a/src/superqt/collapsible/_collapsible.py
+++ b/src/superqt/collapsible/_collapsible.py
@@ -1,212 +1,95 @@
 """A collapsible widget to hide and unhide child widgets"""
-import pathlib
-from typing import Union
+from typing import Optional
 
-from ..qtcompat import QtCore
-from ..qtcompat.QtCore import (
-    QAbstractAnimation,
-    QEasingCurve,
-    QParallelAnimationGroup,
-    QPropertyAnimation,
-    QVariantAnimation,
-)
-from ..qtcompat.QtGui import QIcon, QPixmap, QTransform
-from ..qtcompat.QtWidgets import QAbstractButton, QLayout, QPushButton, QWidget
+from ..qtcompat.QtCore import QAbstractAnimation, QEasingCurve, QPropertyAnimation, Qt
+from ..qtcompat.QtWidgets import QFrame, QPushButton, QVBoxLayout, QWidget
 
 
-class QCollapsible(QPushButton):
+class QCollapsible(QFrame):
     """
-    A collapsible widget to hide and unhide child widgets. This is based on simonxeko solution
-    https://stackoverflow.com/questions/32476006/how-to-make-an-expandable-collapsable-section-widget-in-qt
+    A collapsible widget to hide and unhide child widgets.
+
+    Based on https://stackoverflow.com/a/68141638
     """
 
-    title: str
-    animator: QParallelAnimationGroup
-    hide_show_animation: QPropertyAnimation
-    rotate_animation: QVariantAnimation
-    lock_to: bool
-    content: Union[QWidget, QLayout]
-    icon: QIcon
+    _EXPANDED = "▼  "
+    _COLLAPSED = "▶  "
 
     def __init__(
-        self,
-        content: Union[QWidget, QLayout] = None,
-        duration: int = 500,
-        initial_is_checked: bool = False,
-        lock_to: bool = None,
-        easing_curve: QEasingCurve = QEasingCurve.Type.InOutCubic,
-        is_transparent: bool = True,
-        text_alignment: str = "left",
-        **kwargs,
+        self, title: str = "", parent: Optional[QWidget] = None, flags=Qt.WindowFlags()
     ):
-        """Initializes the component"""
+        super().__init__(parent, flags)
+        self._locked = False
 
-        # Call parent initialization
-        super().__init__(**kwargs)
+        self._toggle_btn = QPushButton(self._EXPANDED + title)
+        self._toggle_btn.setCheckable(True)
+        self._toggle_btn.setChecked(True)
+        self._toggle_btn.setStyleSheet("text-align: left; background: transparent;")
+        self._toggle_btn.clicked.connect(self._toggle)
 
-        # Initialize variables
-        self.title = self.text()
-        self.lock_to = lock_to
-        self.content = content
-
-        # Modify style
-        self.setCheckable(True)
-
-        # Apply special styles
-        style_string = ""
-        if is_transparent:
-            style_string = style_string + "background:rgba(255, 255, 255, 0); "
-        style_string = style_string + f"text-align: {text_alignment};"
-        self.setStyleSheet(style_string)
-
-        # Add icon
-        icons_directory = pathlib.Path(__file__).parent / "resources"
-        icon_filename = str(icons_directory / "right-arrow-black-triangle-sharp.png")
-        icon_pixmap = QPixmap()
-        icon_pixmap.load(icon_filename)
-        self.icon = QIcon(icon_pixmap)
-        self.setIconSize(QtCore.QSize(20, 20))
-        self.setIcon(self.icon)
-
-        # Set conent and button initial state
-        if lock_to is not None:
-            self.setChecked(lock_to)
-        else:
-            self.setChecked(initial_is_checked)
-
-        if content is not None:
-            if initial_is_checked is False:
-                content.setMaximumHeight(0)
-            else:
-                transform = QTransform()
-                transform.rotate(90)
-                icon = QIcon(icon_pixmap.transformed(transform))
-                self.setIcon(icon)
+        # frame layout
+        self.setLayout(QVBoxLayout())
+        self.layout().setAlignment(Qt.AlignTop)
+        self.layout().addWidget(self._toggle_btn)
 
         # Create animators
-        self.animator = QParallelAnimationGroup()
-        self.hide_show_animation = _create_hide_show_animation(
-            content, duration=duration, easing_curve=easing_curve
-        )
-        self.hide_show_animation.setTargetObject(content)
-        self.rotate_animation = _create_icon_rotation_animation(
-            self, duration=duration, easing_curve=easing_curve
-        )
-        self.animator.addAnimation(self.hide_show_animation)
-        self.animator.addAnimation(self.rotate_animation)
+        self._animation = QPropertyAnimation(self)
+        self._animation.setPropertyName(b"maximumHeight")
+        self._animation.setStartValue(0)
+        self.setDuration(300)
+        self.setEasingCurve(QEasingCurve.Type.InOutCubic)
 
-        # Connect events
-        self.clicked.connect(self._toggleHidden)
+        # default content widget
+        _content = QWidget()
+        _content.setLayout(QVBoxLayout())
+        self.setContent(_content)
 
-    def setAnimatationsSettings(
-        self,
-        duration: int = 500,
-        easing_curve: QEasingCurve = QEasingCurve.Type.InOutCubic,
-    ):
-        """Update the animator settings"""
+    def setText(self, text: str):
+        current = self._toggle_btn.text()[: len(self._EXPANDED)]
+        self._toggle_btn.setText(current + text)
 
-        # Easing curve
-        self.hide_show_animation.setEasingCurve(easing_curve)
-        self.rotate_animation.setEasingCurve(easing_curve)
+    def setContent(self, content: QWidget):
+        self._content = content
+        self.layout().addWidget(self._content)
+        self._animation.setTargetObject(content)
 
-        # Duration
-        self.hide_show_animation.setDuration(duration)
-        self.rotate_animation.setDuration(duration)
+    def content(self) -> QWidget:
+        return self._content
 
-    def setContent(self, content: Union[QWidget, QLayout] = None):
-        """Sets the content to collapse"""
-        if isinstance(content, QLayout):
-            self.content = QWidget()
-            self.content.setLayout(content)
-        else:
-            self.content = content
+    def setDuration(self, msecs: int):
+        self._animation.setDuration(msecs)
 
-        self.hide_show_animation.setTargetObject(content)
-        self.hide_show_animation.setPropertyName(b"maximumHeight")
-        self.hide_show_animation.setEndValue(content.sizeHint().height() + 10)
+    def setEasingCurve(self, easing: QEasingCurve):
+        self._animation.setEasingCurve(easing)
 
-    def _toggleHidden(self) -> None:
-        """Toggle the hidden state of the frame"""
+    def addWidget(self, widget: QWidget):
+        self._content.layout().addWidget(widget)
 
-        if self.lock_to is not None and self.isChecked() != self.lock_to:
-            self.setChecked(self.lock_to)
+    def removeWidget(self, widget: QWidget):
+        self._content.layout().removeWidget(widget)
+
+    def expand(self):
+        self._animate(QAbstractAnimation.Direction.Forward)
+
+    def collapse(self):
+        self._animate(QAbstractAnimation.Direction.Backward)
+
+    def _animate(self, direction: QAbstractAnimation.Direction):
+        if self._locked:
             return
+        forward = direction == QAbstractAnimation.Direction.Forward
+        self._toggle_btn.setChecked(forward)
+        text = self._EXPANDED if forward else self._COLLAPSED
+        self._toggle_btn.setText(text + self._toggle_btn.text()[len(self._EXPANDED) :])
+        self._animation.setDirection(direction)
+        self._animation.setEndValue(self._content.sizeHint().height() + 10)
+        self._animation.start()
 
-        if self.lock_to is not None:
-            self.setChecked(self.lock_to)
+    def _toggle(self):
+        self.expand() if self._toggle_btn.isChecked() else self.collapse()
 
-        if self.content is not None:
-            self._showContent() if self.isChecked() else self._hideContent()
+    def setLocked(self, locked: bool = True):
+        self._locked = locked
 
-    def _hideContent(self):
-        """Hides the content"""
-        if self.content is not None:
-            self.animator.setDirection(QAbstractAnimation.Direction.Backward)
-            self.animator.start()
-
-    def _showContent(self):
-        """Show the content"""
-        if self.content is not None:
-            self.animator.setDirection(QAbstractAnimation.Direction.Forward)
-            self.animator.start()
-
-
-def _create_hide_show_animation(
-    widget: QWidget = None,
-    duration: int = 500,
-    easing_curve: QEasingCurve = QEasingCurve.Type.InOutCubic,
-) -> QPropertyAnimation:
-    """
-    Creates an animation that can be used to show animation while hiding and revealing the widget.
-    """
-    animation: QPropertyAnimation
-    if widget is not None:
-        animation = QPropertyAnimation(
-            targetObject=widget, propertyName=b"maximumHeight"
-        )
-        animation.setEndValue(widget.sizeHint().height() + 10)
-    else:
-        animation = QPropertyAnimation()
-        animation.setEndValue(0)
-
-    # Create the animation
-    animation.setStartValue(0)
-    animation.setEasingCurve(easing_curve)
-    animation.setDuration(duration)
-
-    return animation
-
-
-def _create_icon_rotation_animation(
-    widget: QAbstractButton,
-    duration: int = 500,
-    easing_curve: QEasingCurve = QEasingCurve.Type.InOutCubic,
-    start_value: float = 0.0,
-    end_value: float = 90.0,
-) -> QVariantAnimation:
-    """
-    Creates a rotation animation
-    """
-    animation = QVariantAnimation(
-        widget, startValue=start_value, endValue=end_value, duration=duration
-    )
-    animation.setEasingCurve(easing_curve)
-    pixmap = widget.icon.pixmap(widget.iconSize())
-    original_length = pixmap.width()
-
-    def on_value_changed(value):
-        transform = QTransform()
-        transform.rotate(value)
-        transformed_pixmap: QPixmap = pixmap.transformed(transform)
-        xoffset = (transformed_pixmap.width() - original_length) / 2
-        yoffset = (transformed_pixmap.height() - original_length) / 2
-        transformed_pixmap = transformed_pixmap.copy(
-            xoffset, yoffset, original_length, original_length
-        )
-
-        icon = QIcon(transformed_pixmap)
-        widget.setIcon(icon)
-
-    animation.updateCurrentValue = on_value_changed
-
-    return animation
+    def locked(self) -> bool:
+        return self._locked


### PR DESCRIPTION
hey @MosGeo

I played around with your PR today... I love it :)
I got a bit carried away though, tinkering with it... and so I apologize for the big suggestion set, I figured I'd do it as a PR to your branch so you can consider it independently.

I went back to your original implementation of the little caret icon.  So sorry that I sent you down that rabbit hole 😔... I think the difficulties of getting styles to match (independent of stylesheet) are really probably a bigger deal than the rotation animation at this point.  (for example, if you drop it into napari, it's a black icon... and while we could theoretically address that, i think we should punt on it for now).

The rest of these suggestions are mostly just API and code de-duplication.
For API, I think it'd be nice is this was a QFrame that comes with it's own layout, rather than a QPushButton.  (see how simple the example becomes).  People can still create complex layouts and override it with `setContent` ... but for the simpler use case, it's just `addWidget`... and you're done.  I also broke up the two animation options to keep it more like the Qt API.  (now, the methods are all the same as QFrame, QPushButton, and QAnimation ... just combined into one widget).

I removed `lock_to`... since I think the "Qt way" would be to set the expanded state with `collapse/expand` and then just `setLocked`.

let me know what you think!  and sorry again for the large suggestion set